### PR TITLE
Added JSON output format support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.swiftpm
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ make install
 
 From now on you can use the `sitrep` command to scan Swift projects.
 
+## Command line flags
+
+```bash
+sitrep --json
+sitrep ~/path/to/your/project/root --json
+```
+
+You can use the optional `--json` flag to print a pretty formatted JSON output.
+
 
 ## Try it yourself
 
@@ -56,7 +65,7 @@ Sitrep is written using Swift 5.1. You can either build and run the executable d
 
 To build Sitrep, clone this repository and open Terminal in the repository root directory. Then run:
 
-```
+```bash
 swift build
 swift run sitrep ~/path/to/your/project/root
 ```
@@ -74,7 +83,6 @@ Some suggestions you might want to explore:
 
 - Converting more of the tracked data (number of functions, parameters to functions, length of functions, etc) into reported data.
 - Adding a sitrep.yml file that lets users configure how files are scanned, such as the ability to ignore certain directories, what kind of output is printed, or to enable stripped parsing of individual types using `BodyStripper`.
-- Additional command-line options, such as whether to output JSON.
 - Reading more data from the parsed files, and using it to calculate things such as cyclomatic complexity.
 - Reading non-Swift data, such as number of storyboard scenes, number of outlets, number of assets in asset catalogs, etc.
 

--- a/Sources/Sitrep/main.swift
+++ b/Sources/Sitrep/main.swift
@@ -13,12 +13,17 @@ import SitrepCore
 
 let file: String
 
-if CommandLine.arguments.count == 1 {
+let flagPrefix = "--"
+let input = CommandLine.arguments.dropFirst()
+var arguments = input.filter { !$0.hasPrefix(flagPrefix) }
+var flags = input.filter { $0.hasPrefix(flagPrefix) }.map { $0.dropFirst(flagPrefix.count) }
+
+if arguments.isEmpty {
     file = FileManager.default.currentDirectoryPath
 } else {
-    file = CommandLine.arguments[1]
+    file = arguments[0]
 }
 
 let url = URL(fileURLWithPath: file)
 var app = Scan(rootURL: url)
-app.run()
+app.run(reportType: flags.contains("json") ? .json : .text)

--- a/Sources/SitrepCore/Report.swift
+++ b/Sources/SitrepCore/Report.swift
@@ -1,0 +1,60 @@
+//
+// Report.swift
+// Part of Sitrep, a tool for analyzing Swift projects.
+//
+// Copyright (c) 2020 Hacking with Swift
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE for license information
+//
+
+import Foundation
+
+/// The root class for the JSON report
+struct Report: Codable {
+
+    /// A named statistical value
+    struct Stat: Codable {
+        /// Name of the statistic
+        var name: String
+        /// Value of the statistic
+        var value: Int
+    }
+
+    /// Scan related statistics
+    struct Scan: Codable {
+        /// Number of scanned files
+        var scannedFiles: Int
+        /// Total lines of code
+        var totalLinesOfCode: Int
+        /// Total stripped lines of code
+        var totalStrippedLinesOfCode: Int
+        /// Longest file name and lenght
+        var longestFile: Stat?
+        /// Longest type name and lenght 
+        var longestType: Stat?
+    }
+
+    /// Object related statistics
+    struct Object: Codable {
+        /// Number of structs
+        var structs: Int
+        /// Number of classes
+        var classes: Int
+        /// Number of enums
+        var enums: Int
+        /// Number of protocols
+        var protocols: Int
+        /// Number of extensions
+        var extensions: Int
+    }
+
+    /// Scan statistics
+    var scanStats: Scan
+    /// Object statistics
+    var objects: Object
+    /// Import statistics
+    var imports: [Stat]
+    /// Inheritance statistics
+    var inheritances: [Stat]
+}

--- a/Sources/SitrepCore/Results.swift
+++ b/Sources/SitrepCore/Results.swift
@@ -65,4 +65,19 @@ public struct Results {
     var totalStrippedLinesOfCode: Int {
         totalStrippedCode.lines.count
     }
+    
+    /// How many classes inherit from UIView
+    var uiKitViewCount: Int {
+        return classes.sum { $0.inheritance.first == "UIView" }
+    }
+
+    /// How many classes inherit from UIViewController
+    var uiKitViewControllerCount: Int {
+        classes.sum { $0.inheritance.first == "UIViewController" }
+    }
+
+    /// How many structs conform to View
+    var swiftUIViewCount: Int {
+        structs.sum { $0.inheritance.contains("View") }
+    }
 }

--- a/Sources/SitrepCore/Results.swift
+++ b/Sources/SitrepCore/Results.swift
@@ -65,19 +65,4 @@ public struct Results {
     var totalStrippedLinesOfCode: Int {
         totalStrippedCode.lines.count
     }
-
-    /// How many classes inherit from UIView
-    var uiKitViewCount: Int {
-        classes.sum { $0.inheritance.first == "UIView" }
-    }
-
-    /// How many classes inherit from UIViewController
-    var uiKitViewControllerCount: Int {
-        classes.sum { $0.inheritance.first == "UIViewController" }
-    }
-
-    /// How many structs conform to View
-    var swiftUIViewCount: Int {
-        structs.sum { $0.inheritance.first == "View" }
-    }
 }

--- a/Sources/SitrepCore/Scan.swift
+++ b/Sources/SitrepCore/Scan.swift
@@ -145,12 +145,11 @@ public struct Scan {
                 return .init(name: name, value: results.imports.count(for: name))
             }
 
-        let inheritances = results.classes
-            .map { $0.inheritance }
-            .flatMap { $0 }
-            .reduce(into: [:]) { $0[$1, default: 0] += 1 }
-            .sorted(by: { $0.1 > $1.1 })
-            .map { Report.Stat(name: $0.0, value: $0.1) }
+        let inheritances = [
+            Report.Stat(name: "UIViewController", value: results.uiKitViewControllerCount),
+            Report.Stat(name: "UIView", value: results.uiKitViewCount),
+            Report.Stat(name: "SwiftUI.View", value: results.swiftUIViewCount),
+        ]
 
         var longestFileStat: Report.Stat?
         if let longestFile = results.longestFile?.url?.lastPathComponent {
@@ -216,16 +215,14 @@ public struct Scan {
             output.append("   Longest type: \(longestType.name) (\(longestType.value) source lines)")
         }
 
+        let imports = report.imports.map { "\($0.name) (\($0.value))" }.joined(separator: ", ")
+
         output.append("")
         output.append("Structure")
-        output.append("")
-        output.append("   Imports:")
-        output.append("   ---")
-        output.append(report.imports.map { "   \($0.name): \($0.value)" }.joined(separator: "\n"))
-        output.append("")
-        output.append("   Inheritance:")
-        output.append("   ---")
-        output.append(report.inheritances.map { "   \($0.name): \($0.value)" }.joined(separator: "\n"))
+        output.append("   Imports: \(imports)")
+        output.append("   UIKit View Controllers: \(results.uiKitViewControllerCount)")
+        output.append("   UIKit Views: \(results.uiKitViewCount)")
+        output.append("   SwiftUI Views: \(results.swiftUIViewCount)")
         output.append("")
 
         return output.joined(separator: "\n")

--- a/Tests/SitrepCoreTests/SitrepCoreTests.swift
+++ b/Tests/SitrepCoreTests/SitrepCoreTests.swift
@@ -159,6 +159,15 @@ final class SitrepCoreTests: XCTestCase {
         XCTAssertEqual(results.imports.count(for: "UIKit"), 2)
         XCTAssertEqual(results.imports.count(for: "SwiftUI"), 3)
     }
+    
+    func testSpecificInheritances() throws {
+        let app = Scan(rootURL: inputs)
+        let (results, _, _) = app.run(creatingReport: false)
+
+        XCTAssertEqual(results.uiKitViewControllerCount, 2)
+        XCTAssertEqual(results.uiKitViewCount, 0)
+        XCTAssertEqual(results.swiftUIViewCount, 1)
+    }
 
     func testEncoding() throws {
         let input = try getInput("class.swift")
@@ -220,6 +229,8 @@ final class SitrepCoreTests: XCTestCase {
         ("testFileCounts", testFileCounts),
         ("testCollationTypeCounts", testCollationTypeCounts),
         ("testCollationImports", testCollationImports),
+        ("testCollationImports", testCollationImports),
+        ("testSpecificInheritances", testSpecificInheritances),
         ("testEncoding", testEncoding),
         ("testTextReportGeneration", testTextReportGeneration),
         ("testJSONReportGeneration", testJSONReportGeneration),


### PR DESCRIPTION
Hi Paul,

I've got some changes for Sitrep:
- Support for basic command line flags
- A new JSON report format is implemented (--json)
- Altered the text output to use the `Report` object values
- Removed the specific view count inheritance properties from the result
(Report generator has a better solution now, plus I think they were not working properly)
- Fixed some unit tests (two count numbers where always failing for me)
- Updated README.md

Please check my PR & have a nice weekend! 😉

Cheers,
Tib
