### PR TITLE
Fixes #1 - improved type length analysis

### DIFF
--- a/Sources/SitrepCore/FileVisitor.swift
+++ b/Sources/SitrepCore/FileVisitor.swift
@@ -203,8 +203,11 @@ class FileVisitor: SyntaxVisitor {
         let inheritanceClause = node.inheritanceClause?.inheritedTypeCollection.map {
             "\($0.typeName)".trimmingCharacters(in: .whitespacesAndNewlines)
         } ?? []
+        
+        let name = node.name
+            .trimmingCharacters(in: .whitespaces)
 
-        let newObject = Type(type: type, name: node.name, inheritance: inheritanceClause, comments: comments(for: node), body: nodeBody, strippedBody: nodeBodyStripped)
+        let newObject = Type(type: type, name: name, inheritance: inheritanceClause, comments: comments(for: node), body: nodeBody, strippedBody: nodeBodyStripped)
 
         newObject.parent = current
         current?.types.append(newObject)

--- a/Sources/SitrepCore/Scan.swift
+++ b/Sources/SitrepCore/Scan.swift
@@ -84,27 +84,21 @@ public struct Scan {
     func collate(_ scannedFiles: [File]) -> Results {
         var results = Results(files: scannedFiles)
 
+        var allTypesAndLenght = [String: Int]()
+        var allTypesByName = [String: Type]()
+        
         for file in scannedFiles {
             // order all our types by what they are
             for item in file.results.rootNode.types {
+                let name = item.name
+                let typeLength = item.strippedBody.lines.count
+                allTypesAndLenght[name, default: 0] += typeLength
+                allTypesByName[name] = item
+                
                 if item.type == .class {
                     results.classes.append(item)
-
-                    let typeLength = item.strippedBody.lines.count
-
-                    if typeLength > results.longestTypeLength {
-                        results.longestTypeLength = typeLength
-                        results.longestType = item
-                    }
                 } else if item.type == .struct {
                     results.structs.append(item)
-
-                    let typeLength = item.strippedBody.lines.count
-
-                    if typeLength > results.longestTypeLength {
-                        results.longestTypeLength = typeLength
-                        results.longestType = item
-                    }
                 } else if item.type == .enum {
                     results.enums.append(item)
                 } else if item.type == .protocol {
@@ -128,6 +122,12 @@ public struct Scan {
                 results.longestFile = file
                 results.longestFileLength = fileLength
             }
+        }
+        
+        // find the longest type and its length
+        if let longestMatch = allTypesAndLenght.max(by: { $0.value < $1.value }) {
+            results.longestTypeLength = longestMatch.value
+            results.longestType = allTypesByName[longestMatch.key]!
         }
 
         return results

--- a/Tests/SitrepCoreTests/Inputs/type_and_extension.swift
+++ b/Tests/SitrepCoreTests/Inputs/type_and_extension.swift
@@ -1,0 +1,46 @@
+struct Foobar {
+    var text = "Hello, World!"
+}
+
+extension Foobar {
+    func foo() -> Int {
+        var i: Int = 0
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        i += 1
+        return i
+    }
+}

--- a/Tests/SitrepCoreTests/SitrepCoreTests.swift
+++ b/Tests/SitrepCoreTests/SitrepCoreTests.swift
@@ -117,7 +117,7 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let files = app.detectFiles()
 
-        XCTAssertEqual(files.count, 8)
+        XCTAssertEqual(files.count, 9)
     }
 
     func testBadFileScanning() throws {
@@ -137,7 +137,7 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let (_, files, failures) = app.run(creatingReport: false)
 
-        XCTAssertEqual(files.count, 8)
+        XCTAssertEqual(files.count, 9)
         XCTAssertEqual(failures.count, 0)
     }
 
@@ -146,10 +146,10 @@ final class SitrepCoreTests: XCTestCase {
         let (results, _, _) = app.run(creatingReport: false)
 
         XCTAssertEqual(results.classes.count, 3)
-        XCTAssertEqual(results.structs.count, 2)
+        XCTAssertEqual(results.structs.count, 3)
         XCTAssertEqual(results.enums.count, 1)
         XCTAssertEqual(results.protocols.count, 4)
-        XCTAssertEqual(results.extensions.count, 1)
+        XCTAssertEqual(results.extensions.count, 2)
     }
 
     func testCollationImports() throws {
@@ -211,8 +211,18 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let (_, files, failures) = app.run(creatingReport: true)
 
-        XCTAssertEqual(files.count, 8)
+        XCTAssertEqual(files.count, 9)
         XCTAssertEqual(failures.count, 0)
+    }
+    
+    func testLongestType() throws {
+        let app = Scan(rootURL: inputs)
+        let (results, _, _) = app.run(creatingReport: false)
+        
+        // Code in extensions should count towards the length of the type they're extending.
+        // https://github.com/twostraws/Sitrep/issues/1
+        XCTAssertEqual(results.longestType?.name, "Foobar")
+        XCTAssertEqual(results.longestTypeLength, 45)
     }
 
     static var allTests = [
@@ -235,6 +245,7 @@ final class SitrepCoreTests: XCTestCase {
         ("testTextReportGeneration", testTextReportGeneration),
         ("testJSONReportGeneration", testJSONReportGeneration),
         ("testBodyStripperRemovedComments", testBodyStripperRemovedComments),
-        ("testCreatingReport", testCreatingReport)
+        ("testCreatingReport", testCreatingReport),
+        ("testLongestType", testLongestType)
     ]
 }


### PR DESCRIPTION
This fixes #1 by gathering all types (no matter which kind they're) by name in order to count their length, this "deduplicates" types with the same name (like extensions and their original type). Then we just need to find the longest. 

Some notes:
- I'm keeping local vars to gather all types, maybe this would be useful as part of `Results`? One thing to now is that I'm gathering them based on their name, ignoring the rest of the type. But if we want to keep this data around we are losing information: we would have a `struct` or its `extension` but not both. I'm not sure if the current models have some way of keeping these relations while just keeping 1 type in the results. 
- I'm keeping the types in a couple of Dictionary keyed by name. Ideally a Set would be used to avoid duplicates but that doesn't help much since: 1. Type is not hashable; 2. even if we make it hashbable, the types are really different, only their name is the same. 
- For testing I added a new file (so I had to update some numbers) that reflects the exact error reported #1. Tell me if you prefer to test this in another way. 
- I added the test at the end for my convenience but if you prefer it in another position that makes more sense we can move it ^^

I hope this is useful ^^