### PR TITLE
Fix unit tests

### DIFF
--- a/Sources/Sitrep/Command.swift
+++ b/Sources/Sitrep/Command.swift
@@ -31,6 +31,6 @@ struct Command: ParsableCommand {
         
         let url = URL(fileURLWithPath: path)
         let app = Scan(rootURL: url)
-        app.run(reportType: self.format, path: path, configuration: configuration)
+        app.run(reportType: self.format, configuration: configuration)
     }
 }

--- a/Sources/SitrepCore/Scan.swift
+++ b/Sources/SitrepCore/Scan.swift
@@ -44,9 +44,8 @@ public struct Scan {
     @discardableResult
     public func run(creatingReport: Bool = true,
                     reportType: ReportType = .text,
-                    path: String,
                     configuration: Configuration = Configuration.default) -> (results: Results, files: [URL], failures: [URL]) {
-        let detectedFiles = detectFiles(excludedPath: configuration.excludedPath(path: path))
+        let detectedFiles = detectFiles(excludedPath: configuration.excludedPath(path: rootURL.path))
         let (scannedFiles, failures) = parse(files: detectedFiles)
         let results = collate(scannedFiles)
 

--- a/Sources/SitrepCore/Scan.swift
+++ b/Sources/SitrepCore/Scan.swift
@@ -63,7 +63,7 @@ public struct Scan {
         return (results, detectedFiles, failures)
     }
 
-    private func detectFiles(excludedPath: [String]) -> [URL] {
+    func detectFiles(excludedPath: [String] = []) -> [URL] {
         let fileManager = FileManager.default
         let enumerator = fileManager.enumerator(at: rootURL, includingPropertiesForKeys: nil)
 


### PR DESCRIPTION
1. Empty array default value for detectFiles(excludedPath:) 
2. The path for excluded configuration is the same as rootURL's, so we don't need to pass it again.