### PR TITLE
Support swift 5.2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Xcode_11.4
+      run: sudo xcode-select --switch /Applications/Xcode_11.4.app/Contents/Developer
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "35b76bf577d3cc74820f8991894ce3bcdf024ddc",
-          "version": "0.0.2"
+          "revision": "8d31a0905c346a45c87773ad50862b5b3df8dff6",
+          "version": "0.0.4"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
-          "version": "0.50100.0"
+          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
+          "version": "0.50200.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,13 +12,18 @@ let package = Package(
         .executable(name: "sitrep", targets: ["Sitrep"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
     ],
     targets: [
-        .target(name: "Sitrep", dependencies: ["SitrepCore", "ArgumentParser"]),
-        .target(name: "SitrepCore", dependencies: ["SwiftSyntax", "Yams", "ArgumentParser"]),
+        .target(name: "Sitrep", dependencies: ["SitrepCore",
+                                               .product(name: "ArgumentParser",
+                                                        package: "swift-argument-parser")]),
+        .target(name: "SitrepCore", dependencies: ["SwiftSyntax",
+                                                   "Yams",
+                                                   .product(name: "ArgumentParser",
+                                                            package: "swift-argument-parser")]),
         .testTarget(name: "SitrepCoreTests", dependencies: ["SitrepCore"], exclude: ["Inputs"])
     ]
 )

--- a/Sources/SitrepCore/BodyStripper.swift
+++ b/Sources/SitrepCore/BodyStripper.swift
@@ -17,7 +17,7 @@ class BodyStripper: SyntaxRewriter {
     override func visit(_ token: TokenSyntax) -> Syntax {
         let leading = clean(trivia: token.leadingTrivia)
         let trailing = clean(trivia: token.trailingTrivia)
-        return token.withLeadingTrivia(leading).withTrailingTrivia(trailing)
+        return Syntax(token.withLeadingTrivia(leading).withTrailingTrivia(trailing))
     }
 
     /// This removes all comments plus tab and spaces, and also collapses line breaks

--- a/Sources/SitrepCore/File.swift
+++ b/Sources/SitrepCore/File.swift
@@ -26,7 +26,7 @@ struct File {
 
         let sourceFile = try SyntaxParser.parse(url)
         results = FileVisitor()
-        sourceFile.walk(&results)
+        results.walk(sourceFile)
     }
 
     /// Creates an instance of the scanner from a string, then starts it walking through code
@@ -35,7 +35,7 @@ struct File {
         results = FileVisitor()
 
         let sourceFile = try SyntaxParser.parse(source: sourceCode)
-        sourceFile.walk(&results)
+        results.walk(sourceFile)
     }
 
     /// Writes this file's tree to a JSON string for testing

--- a/Sources/SitrepCore/FileVisitor.swift
+++ b/Sources/SitrepCore/FileVisitor.swift
@@ -36,45 +36,45 @@ class FileVisitor: SyntaxVisitor {
     }()
 
     /// Triggered on entering a class
-    func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         create(.class, from: node)
         return .visitChildren
     }
 
     /// Triggered on exiting a class; moves back up the tree
-    func visitPost(_ node: ClassDeclSyntax) {
+    override func visitPost(_ node: ClassDeclSyntax) {
         current = current?.parent
     }
 
     /// Triggered on entering an enum
-    func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         create(.enum, from: node)
         return .visitChildren
     }
 
     /// Triggered on exiting an enum; moves back up the tree
-    func visitPost(_ node: EnumDeclSyntax) {
+    override func visitPost(_ node: EnumDeclSyntax) {
         current = current?.parent
     }
 
     /// Triggered on exiting a single enum case
-    func visitPost(_ node: EnumCaseElementSyntax) {
+    override func visitPost(_ node: EnumCaseElementSyntax) {
         current?.cases.append(node.identifier.text)
     }
 
     /// Triggered on entering an extension
-    func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
         create(.extension, from: node)
         return .visitChildren
     }
 
     /// Triggered on exiting an extension; moves back up the tree
-    func visitPost(_ node: ExtensionDeclSyntax) {
+    override func visitPost(_ node: ExtensionDeclSyntax) {
         current = current?.parent
     }
 
     /// Triggered on entering a function
-    func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         var throwingStatus = Function.ThrowingStatus.unknown
         var isStatic = false
         var returnType = ""
@@ -120,50 +120,50 @@ class FileVisitor: SyntaxVisitor {
     }
 
     /// Triggered on exiting a function; moves back up the tree
-    func visitPost(_ node: FunctionDeclSyntax) {
+    override func visitPost(_ node: FunctionDeclSyntax) {
         current = current?.parent
     }
 
     /// Triggered on entering an identifer pattern – the part of a variable that contains its name
-    func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
         current?.variables.append(node.identifier.text)
         return .visitChildren
     }
 
     /// Triggered on finding an import statement
-    func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
         let importName = node.path.description
         imports.append(importName)
         return .visitChildren
     }
 
     /// Triggered on entering a protocol
-    func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         create(.protocol, from: node)
         return .visitChildren
     }
 
     /// Triggered on exiting a protocol; moves back up the tree
-    func visitPost(_ node: ProtocolDeclSyntax) {
+    override func visitPost(_ node: ProtocolDeclSyntax) {
         current = current?.parent
     }
 
     /// Triggered on entering a file
-    func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
-        comments = comments(for: node)
+    override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        comments = comments(for: node._syntaxNode)
         body = "\(node)"
         strippedBody = body.removingDuplicateLineBreaks()
         return .visitChildren
     }
 
     /// Triggered on entering a struct
-    func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
         create(.struct, from: node)
         return .visitChildren
     }
 
     /// Triggered on exiting a struct; moves back up the tree
-    func visitPost(_ node: StructDeclSyntax) {
+    override func visitPost(_ node: StructDeclSyntax) {
         current = current?.parent
     }
 
@@ -207,7 +207,7 @@ class FileVisitor: SyntaxVisitor {
         let name = node.name
             .trimmingCharacters(in: .whitespaces)
 
-        let newObject = Type(type: type, name: name, inheritance: inheritanceClause, comments: comments(for: node), body: nodeBody, strippedBody: nodeBodyStripped)
+        let newObject = Type(type: type, name: name, inheritance: inheritanceClause, comments: comments(for: node._syntaxNode), body: nodeBody, strippedBody: nodeBodyStripped)
 
         newObject.parent = current
         current?.types.append(newObject)
@@ -228,7 +228,7 @@ class FileVisitor: SyntaxVisitor {
 }
 
 /// The handful of common things we use across types
-protocol CommonSyntax: Syntax {
+protocol CommonSyntax: SyntaxProtocol {
     var inheritanceClause: SwiftSyntax.TypeInheritanceClauseSyntax? { get set }
     var name: String { get }
     var leadingTrivia: SwiftSyntax.Trivia? { get set }


### PR DESCRIPTION
I've added support for Xcode 11.4 and swift 5.2, while also updating SwiftSyntax dependency.
Tests are passing.
So if you think it's useful and in good shape, you could merge it.

I've another approach which preserves both swift 5.1 and swift 5.2, but I think it's more ugly and difficult to maintain. And as SwiftSyntax is a highly changing dependency, I don't think preserving compatibility with both versions is really useful at the moment.

Regards and thanks for your work on this tool.