### PR TITLE
Removed unnecessary FileVisitor creation

### DIFF
--- a/Sources/SitrepCore/File.swift
+++ b/Sources/SitrepCore/File.swift
@@ -23,9 +23,8 @@ struct File {
     init(url: URL) throws {
         self.url = url
         results = FileVisitor()
-
+        
         let sourceFile = try SyntaxParser.parse(url)
-        results = FileVisitor()
         results.walk(sourceFile)
     }
 


### PR DESCRIPTION
Found a duplicate where the FileVisitor in the initialiser was created twice.