### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ From now on you can use the `sitrep` command to scan Swift projects.
 Alternatively, you can install the tool by using [Mint](https://github.com/yonaskolb/Mint) as follows:
 
 ```bash
-$ mint install twostraws/Sitrep
+$ mint install twostraws/Sitrep@main
 ```
     
 And then run it using:
 
 ```bash
-$ mint run sitrep
+$ mint run sitrep@main
 ```
 
 ## Command line flags


### PR DESCRIPTION
This project uses `main` instead of `master` and also has no release tags, so mint tries to install from a non-existing master branch and fails. Specifying `@main` seems to fix the install and well as the mint run command. As an alternative, you could make a release tag, but I thought making a PR would be more helpful for discussion.