### PR TITLE
Fix incorrect branch name in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ First, add Sitrep as a dependency in your `Package.swift` file:
 let package = Package(
     //...
     dependencies: [
-        .package(url: "https://github.com/twostraws/Sitrep", .branch("master"))
+        .package(url: "https://github.com/twostraws/Sitrep", .branch("main"))
     ],
     //...
 )


### PR DESCRIPTION
The default branch is `main`, but the Swift Package Manager example still references `master`, which would cause resolution to fail.