### PR TITLE
Add UIKit & SwiftUI LOC calculation

### DIFF
--- a/Sources/SitrepCore/Extensions.swift
+++ b/Sources/SitrepCore/Extensions.swift
@@ -39,3 +39,45 @@ extension String {
         return nonEmptyLines.joined(separator: "\n")
     }
 }
+
+extension Collection where Element == Type {
+    /// Returns filtered types which are extended by provided type names
+    func extending(from typeNames: [String]) -> [Element] {
+        let descendants = descendants()
+        return typeNames.flatMap { extending(from: $0, descendants: descendants) }
+    }
+    
+    /// Returns filtered types which are extended by provided type name
+    func extending(from typeName: String, descendants: [String: String]) -> [Element] {
+        return filter { $0.extends(from: typeName, descendants: descendants) }
+    }
+    
+    /// Returns a map with all possible descendants in the collection
+    func descendants() -> [String: String] {
+        var map = [String: String]()
+        for type in self {
+            guard let inheritance = type.inheritance.first else { continue }
+            map[type.name] = inheritance
+        }
+        return map
+    }
+}
+
+private extension Type {
+    /// Checks whether the type is extended by the `typeName` by looking into all descendants
+    func extends(from typeName: String, descendants: [String: String]) -> Bool {
+        var current: String? = name
+        var visited = Set<String>()
+        
+        while let name = current {
+            if visited.contains(name) { return false }
+            visited.insert(name)
+           
+            if name == typeName { return true }
+            current = descendants[name]
+        }
+        
+        return false
+    }
+}
+

--- a/Sources/SitrepCore/Report.swift
+++ b/Sources/SitrepCore/Report.swift
@@ -33,6 +33,10 @@ public struct Report: Codable {
         public var longestFile: Stat?
         /// Longest type name and length 
         public var longestType: Stat?
+        /// UIKit lines of code
+        public var uiKitLinesOfCode: Int
+        /// SwiftUI lines of code
+        public var swiftUILinesOfCode: Int
     }
 
     /// Object related statistics

--- a/Sources/SitrepCore/Results.swift
+++ b/Sources/SitrepCore/Results.swift
@@ -83,10 +83,7 @@ public struct Results {
 
     /// The total number of striped lines of code scanned across all files and related to UIKit
     var uiKitLinesOfCode: Int {
-        let uiKitClasses: [String] = [
-            "UIApplication", "UIWindow", "UINavigationController", "UISplitViewController", "UIViewController", "UIView", "UITableViewController", "UITableView", "UITableViewCell", "UIScrollView", "UIBarButtonItem", "UIBarItem", "UITabBarController", "UITabBarItem", "UIStackView", "UICollectionView", "UICollectionViewCell", "UIButton", "UIControl", "UITextView", "UITextField", "UILabel", "UIPickerView", "UIImageView", "UISwitch", "MKMapView", "MKAnnotationView"
-        ]
-        let filteredClasses = classes.extending(from: uiKitClasses)
+        let filteredClasses = classes.extending(from: Type.uiKitClasses)
         let classesLinesOfCode = filteredClasses.reduce(0) { result, type in
             return result + type.strippedBody.lines.count
         }
@@ -98,7 +95,7 @@ public struct Results {
         let portsLinesOfCode = filteredPorts.reduce(0) { result, type in
             return result + type.strippedBody.lines.count
         }
-        let extensionTypes = filteredClasses.map { $0.name } + uiKitClasses + filteredPorts.map { $0.name } + portTypes
+        let extensionTypes = filteredClasses.map { $0.name } + Type.uiKitClasses + filteredPorts.map { $0.name } + portTypes
         let extensionsLinesOfCode = extensions.reduce(0) { result, type in
             guard extensionTypes.contains(type.name) else { return result }
             return result + type.strippedBody.lines.count
@@ -108,15 +105,15 @@ public struct Results {
 
     /// The total number of striped lines of code scanned across all files and related to SwiftUI
     var swiftUILinesOfCode: Int {
-        let viewTypes = structs.filter { $0.inheritance.first == "View" }
-        let viewsLinesOfCode = viewTypes.reduce(0) { result, type in
+        let uiTypes = structs.extending(from: Type.swiftUIProtocols)
+        let uiLinesOfCode = uiTypes.reduce(0) { result, type in
             return result + type.strippedBody.lines.count
         }
-        let extensionTypes = viewTypes.map { $0.name } + ["View"]
+        let extensionTypes = uiTypes.map { $0.name } + Type.swiftUIProtocols
         let extensionsLinesOfCode = extensions.reduce(0) { result, type in
             guard extensionTypes.contains(type.name) else { return result }
             return result + type.strippedBody.lines.count
         }
-        return viewsLinesOfCode + extensionsLinesOfCode
+        return uiLinesOfCode + extensionsLinesOfCode
     }
 }

--- a/Sources/SitrepCore/Results.swift
+++ b/Sources/SitrepCore/Results.swift
@@ -80,4 +80,43 @@ public struct Results {
     var swiftUIViewCount: Int {
         structs.sum { $0.inheritance.contains("View") }
     }
+
+    /// The total number of striped lines of code scanned across all files and related to UIKit
+    var uiKitLinesOfCode: Int {
+        let uiKitClasses: [String] = [
+            "UIApplication", "UIWindow", "UINavigationController", "UISplitViewController", "UIViewController", "UIView", "UITableViewController", "UITableView", "UITableViewCell", "UIScrollView", "UIBarButtonItem", "UIBarItem", "UITabBarController", "UITabBarItem", "UIStackView", "UICollectionView", "UICollectionViewCell", "UIButton", "UIControl", "UITextView", "UITextField", "UILabel", "UIPickerView", "UIImageView", "UISwitch", "MKMapView", "MKAnnotationView"
+        ]
+        let filteredClasses = classes.extending(from: uiKitClasses)
+        let classesLinesOfCode = filteredClasses.reduce(0) { result, type in
+            return result + type.strippedBody.lines.count
+        }
+        let portTypes = ["UIViewRepresentable", "UIViewControllerRepresentable"]
+        let filteredPorts = structs.filter {
+            guard let inheritance = $0.inheritance.first else { return false }
+            return portTypes.contains(inheritance)
+        }
+        let portsLinesOfCode = filteredPorts.reduce(0) { result, type in
+            return result + type.strippedBody.lines.count
+        }
+        let extensionTypes = filteredClasses.map { $0.name } + uiKitClasses + filteredPorts.map { $0.name } + portTypes
+        let extensionsLinesOfCode = extensions.reduce(0) { result, type in
+            guard extensionTypes.contains(type.name) else { return result }
+            return result + type.strippedBody.lines.count
+        }
+        return classesLinesOfCode + portsLinesOfCode + extensionsLinesOfCode
+    }
+
+    /// The total number of striped lines of code scanned across all files and related to SwiftUI
+    var swiftUILinesOfCode: Int {
+        let viewTypes = structs.filter { $0.inheritance.first == "View" }
+        let viewsLinesOfCode = viewTypes.reduce(0) { result, type in
+            return result + type.strippedBody.lines.count
+        }
+        let extensionTypes = viewTypes.map { $0.name } + ["View"]
+        let extensionsLinesOfCode = extensions.reduce(0) { result, type in
+            guard extensionTypes.contains(type.name) else { return result }
+            return result + type.strippedBody.lines.count
+        }
+        return viewsLinesOfCode + extensionsLinesOfCode
+    }
 }

--- a/Sources/SitrepCore/Scan.swift
+++ b/Sources/SitrepCore/Scan.swift
@@ -66,8 +66,17 @@ public struct Scan {
 
     public func detectFiles(excludedPath: [String] = []) -> [URL] {
         let fileManager = FileManager.default
-        let enumerator = fileManager.enumerator(at: rootURL, includingPropertiesForKeys: nil)
-
+        
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory), !isDirectory.boolValue {
+            let isExcluded = excludedPath.contains { rootURL.deletingLastPathComponent().relativePath.hasPrefix($0) }
+            if rootURL.pathExtension == "swift" && !isExcluded {
+                return [rootURL]
+            }
+            return []
+        }
+        
+        let enumerator = fileManager.enumerator(at: rootURL, includingPropertiesForKeys: [.isRegularFileKey])
         var detectedFiles = [URL]()
 
         while let objectURL = enumerator?.nextObject() as? URL {
@@ -92,9 +101,10 @@ public struct Scan {
         var failures = [URL]()
 
         for file in files {
-            if let file = try? File(url: file) {
+            do {
+                let file = try File(url: file)
                 scannedFiles.append(file)
-            } else {
+            } catch {
                 failures.append(file)
             }
         }
@@ -190,7 +200,9 @@ public struct Scan {
                                       totalLinesOfCode: results.totalLinesOfCode,
                                       totalStrippedLinesOfCode: results.totalStrippedLinesOfCode,
                                       longestFile: longestFileStat,
-                                      longestType: longestTypeStat),
+                                      longestType: longestTypeStat,
+                                      uiKitLinesOfCode: results.uiKitLinesOfCode,
+                                      swiftUILinesOfCode: results.swiftUILinesOfCode),
                      objects: .init(structs: results.structs.count,
                                     classes: results.classes.count,
                                     enums: results.enums.count,
@@ -250,7 +262,9 @@ public struct Scan {
         output.append("   Imports: \(imports)")
         output.append("   UIKit View Controllers: \(results.uiKitViewControllerCount)")
         output.append("   UIKit Views: \(results.uiKitViewCount)")
+        output.append("   UIKit lines of code: \(results.uiKitLinesOfCode)")
         output.append("   SwiftUI Views: \(results.swiftUIViewCount)")
+        output.append("   SwiftUI lines of code: \(results.swiftUILinesOfCode)")
         output.append("")
 
         return output.joined(separator: "\n")

--- a/Sources/SitrepCore/Scan.swift
+++ b/Sources/SitrepCore/Scan.swift
@@ -67,6 +67,7 @@ public struct Scan {
     public func detectFiles(excludedPath: [String] = []) -> [URL] {
         let fileManager = FileManager.default
         
+        // Handle the case where the rootURL points directly to the single file instead of a directory and returns the same rootUrl
         var isDirectory: ObjCBool = false
         if fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory), !isDirectory.boolValue {
             let isExcluded = excludedPath.contains { rootURL.deletingLastPathComponent().relativePath.hasPrefix($0) }

--- a/Sources/SitrepCore/Type.swift
+++ b/Sources/SitrepCore/Type.swift
@@ -63,3 +63,44 @@ class Type: Node {
         try container.encode(strippedBody, forKey: .strippedBody)
     }
 }
+
+extension Type {
+    static let uiKitClasses: [String] = [
+        "MKAnnotationView",
+        "MKMapView",
+        "UIApplication",
+        "UIBarButtonItem",
+        "UIBarItem",
+        "UIButton",
+        "UICollectionView",
+        "UICollectionViewCell",
+        "UIControl",
+        "UIImageView",
+        "UILabel",
+        "UINavigationController",
+        "UIPickerView",
+        "UIScrollView",
+        "UISplitViewController",
+        "UIStackView",
+        "UISwitch",
+        "UITabBarController",
+        "UITabBarItem",
+        "UITableView",
+        "UITableViewCell",
+        "UITableViewController",
+        "UITextField",
+        "UITextView",
+        "UIView",
+        "UIViewController",
+        "UIWindow",
+    ]
+    
+    static let swiftUIProtocols: [String] = [
+        "App",
+        "ButtonStyle",
+        "ShapeStyle",
+        "View",
+        "ViewModifier",
+        "Label"
+    ]
+}

--- a/Tests/SitrepCoreTests/Inputs/swiftui_lines_of_code.swift
+++ b/Tests/SitrepCoreTests/Inputs/swiftui_lines_of_code.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ListView: View {
+    var body: some View {
+        Text("List")
+    }
+}
+
+extension ListView {
+    func listId() -> some View {
+        id("List")
+    }
+}
+
+struct DetailsView: View {
+    var body: some View {
+        Text("Details")
+    }
+}
+
+extension DetailsView {
+    func detailsId() -> some View {
+        id("Details")
+    }
+}
+
+extension View {
+    func anyId() -> some View {
+        return id(UUID().uuidString)
+    }
+}

--- a/Tests/SitrepCoreTests/Inputs/uikit_lines_of_code.swift
+++ b/Tests/SitrepCoreTests/Inputs/uikit_lines_of_code.swift
@@ -1,0 +1,83 @@
+import UIKit
+
+class BaseViewController: UIViewController {
+    let name: String = ""
+}
+
+class FeatureViewController: BaseViewController {
+    let subname: String = ""
+}
+
+extension BaseViewController {
+    func base() {
+        print("BaseViewController")
+    }
+}
+
+extension FeatureViewController {
+    func feature() {
+        print("FeatureViewController")
+    }
+}
+
+class BaseView: UIView {
+    let name: String = ""
+}
+
+class FeatureView: BaseView {
+    let subname: String = ""
+}
+
+extension BaseView {
+    func base() {
+        print("BaseViewController")
+    }
+}
+
+extension FeatureView {
+    func feature() {
+        print("FeatureViewController")
+    }
+}
+
+struct ViewControllerRepresentable: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        return UIViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}
+
+extension ViewControllerRepresentable {
+    func representable() {
+        print("ViewControllerRepresentable")
+    }
+}
+
+struct ViewRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        return UIView()
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+    }
+}
+
+extension ViewRepresentable {
+    func representable() {
+        print("ViewRepresentable")
+    }
+}
+
+extension UIViewController {
+    func example() {
+        print("Example")
+    }
+}
+
+extension UIView {
+    func example() {
+        print("Example")
+    }
+}

--- a/Tests/SitrepCoreTests/SitrepCoreTests.swift
+++ b/Tests/SitrepCoreTests/SitrepCoreTests.swift
@@ -122,7 +122,7 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let files = app.detectFiles()
 
-        XCTAssertEqual(files.count, 10)
+        XCTAssertEqual(files.count, 12)
     }
 
     func testBadFileScanning() throws {
@@ -142,7 +142,7 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let (_, files, failures) = app.run(creatingReport: false)
 
-        XCTAssertEqual(files.count, 10)
+        XCTAssertEqual(files.count, 12)
         XCTAssertEqual(failures.count, 0)
     }
 
@@ -150,28 +150,28 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let (results, _, _) = app.run(creatingReport: false)
 
-        XCTAssertEqual(results.classes.count, 4)
-        XCTAssertEqual(results.structs.count, 3)
+        XCTAssertEqual(results.classes.count, 8)
+        XCTAssertEqual(results.structs.count, 7)
         XCTAssertEqual(results.enums.count, 1)
         XCTAssertEqual(results.protocols.count, 4)
-        XCTAssertEqual(results.extensions.count, 2)
+        XCTAssertEqual(results.extensions.count, 13)
     }
 
     func testCollationImports() throws {
         let app = Scan(rootURL: inputs)
         let (results, _, _) = app.run(creatingReport: false)
 
-        XCTAssertEqual(results.imports.count(for: "UIKit"), 2)
-        XCTAssertEqual(results.imports.count(for: "SwiftUI"), 3)
+        XCTAssertEqual(results.imports.count(for: "UIKit"), 3)
+        XCTAssertEqual(results.imports.count(for: "SwiftUI"), 4)
     }
 
     func testSpecificInheritances() throws {
         let app = Scan(rootURL: inputs)
         let (results, _, _) = app.run(creatingReport: false)
 
-        XCTAssertEqual(results.uiKitViewControllerCount, 2)
-        XCTAssertEqual(results.uiKitViewCount, 0)
-        XCTAssertEqual(results.swiftUIViewCount, 1)
+        XCTAssertEqual(results.uiKitViewControllerCount, 3)
+        XCTAssertEqual(results.uiKitViewCount, 1)
+        XCTAssertEqual(results.swiftUIViewCount, 3)
     }
 
     func testEncoding() throws {
@@ -216,7 +216,7 @@ final class SitrepCoreTests: XCTestCase {
         let app = Scan(rootURL: inputs)
         let (_, files, failures) = app.run(creatingReport: true)
 
-        XCTAssertEqual(files.count, 10)
+        XCTAssertEqual(files.count, 12)
         XCTAssertEqual(failures.count, 0)
     }
 
@@ -235,9 +235,24 @@ final class SitrepCoreTests: XCTestCase {
         let config = Configuration(excluded: ["IgnoredDirectory"])
         let (_, files, _) = app.run(reportType: .json, configuration: config)
 
-        XCTAssertEqual(files.count, 9, "There should be 9 files in all test inputs, because IgnoredDirectory should be excluded.")
+        XCTAssertEqual(files.count, 11, "There should be 11 files in all test inputs, because IgnoredDirectory should be excluded.")
     }
-
+    
+    func testUIKitLinesOfCode() throws {
+        let input = try getInput("uikit_lines_of_code.swift")
+        let app = Scan(rootURL: input)
+        let (results, _, _) = app.run(creatingReport: false)
+        XCTAssertEqual(results.uiKitLinesOfCode, 66)
+    }
+    
+    
+    func testSwiftUILinesOfCode() throws {
+        let input = try getInput("swiftui_lines_of_code.swift")
+        let app = Scan(rootURL: input)
+        let (results, _, _) = app.run(creatingReport: false)
+        XCTAssertEqual(results.swiftUILinesOfCode, 25)
+    }
+    
     static var allTests = [
         ("testClassDetection", testClassDetection),
         ("testStructDetection", testStructDetection),
@@ -260,6 +275,8 @@ final class SitrepCoreTests: XCTestCase {
         ("testBodyStripperRemovedComments", testBodyStripperRemovedComments),
         ("testCreatingReport", testCreatingReport),
         ("testLongestType", testLongestType),
-        ("testIgnoredFiles", testIgnoredFiles)
+        ("testIgnoredFiles", testIgnoredFiles),
+        ("testUIKitLinesOfCode", testUIKitLinesOfCode),
+        ("testSwiftUILinesOfCode", testSwiftUILinesOfCode)
     ]
 }


### PR DESCRIPTION
### Summary
This PR introduces UIKit & SwiftUI Lines of Code (LOC) metrics, giving users better visibility into how much of their project relies on UIKit versus SwiftUI.

### Key Changes:
Framework LOC Metrics: Added uiKitLinesOfCode and swiftUILinesOfCode to the analyzer and report outputs. This actively calculates stripped lines of code across base classes, representables, protocols, and extensions by resolving inheritance maps.

Inheritance Resolution: Added new Collection extensions (extending(from:), descendants()) to recursively check type inheritance and extensions for more accurate stats.

Single-File Scanning Support: Updated Scan.detectFiles to support targeting a single file path directly, bypassing the directory enumerator when a specific file is passed.

Improved Error Handling: Replaced the try? initialization in the scanning loop with a do/catch block to accurately populate the failures array when a file fails to be read.

Testing: Included new dedicated input files (swiftui_lines_of_code.swift, uikit_lines_of_code.swift) and updated the test suite to validate framework-specific LOC counts.

### Output:
```
SITREP
------

Overview
   Files scanned: 31
   Structs: 14
   Classes: 15
   Enums: 1
   Protocols: 5
   Extensions: 24

Sizes
   Total lines of code: 1917
   Source lines of code: 1570
   Longest file: SitrepCoreTests.swift (241 source lines)
   Longest type: SitrepCoreTests (232 source lines)

Structure
   Imports: Foundation (16), XCTest (5), SwiftUI (4), SwiftSyntax (3), UIKit (3), SitrepCore (2), ArgumentParser (2), SwiftParser (2), Combine (2), Foundation.Bundle (2), SitrepTests (1), SitrepCoreTests (1), CoreImage (1), Sitrep (1), MapKit (1), PackageDescription (1), Yams (1)
   UIKit View Controllers: 3
   UIKit Views: 1
   UIKit lines of code: 107
   SwiftUI Views: 3
   SwiftUI lines of code: 30
```